### PR TITLE
[Dev] RouteList를 반환하는 API구성

### DIFF
--- a/src/Routes/FindRouteAPI.ts
+++ b/src/Routes/FindRouteAPI.ts
@@ -16,6 +16,23 @@ findRouteRouter.post("/", async (req: Request, res: Response) => {
         "weight_factor": 2,
         "share_factor": 1
     };
+    const instructionTypes = {
+        0: "좌회전", //Left
+        1: "우회전", //Right
+        2: "7시 방향", //Sharp left
+        3: "5시 방향", //Sharp right
+        4: "11시 방향", //Slight left
+        5: "1시 방향", //Slight right
+        6: "직진", //Straight
+        7: "회전교차로 진입", //Enter roundabout
+        8: "회전교차로 탈출", //Exit roundabout
+        9: "유턴", //U-turn
+        10: "목적지 도착", //Goal
+        11: "출발", //Depart
+        12: "왼쪽으로 크게 돌기", //keep left
+        13: "오른쪽으로 크게 돌기", //keep right
+
+    }
 
     alternativeRoutesConfig["target_count"] = req.body?.targetCount ?? alternativeRoutesConfig["target_count"];
     alternativeRoutesConfig["weight_factor"] = req.body?.targetCount ?? alternativeRoutesConfig["weight_factor"];
@@ -47,16 +64,20 @@ findRouteRouter.post("/", async (req: Request, res: Response) => {
         RESULT_DATA["RESULT_MSG"] = routeMsg.statusText;
         if (routeMsg.status === 200) {
             RESULT_DATA['RESULT_DATA'] = {
-                routeList: routeMsg.data.features.map(({geometry: geometry}: any, index: number) => {
+                routeList: routeMsg.data.features.map(({
+                                                           geometry: geometry,
+                                                           properties: properties
+                                                       }: any, index: number) => {
+                    const detailRouteInfo = properties.segments[0];
                     return {
                         id: index,
                         description: `Route ${index}`,
                         route: {
+                            distance: detailRouteInfo.distance,
+                            duration: detailRouteInfo.duration,
+                            steps: detailRouteInfo.steps,
                             coordinates: geometry.coordinates.map((coordinate: [number, number]) => {
-                                return {
-                                    description: "walking",
-                                    coordinate: [coordinate[1], coordinate[0]]
-                                };
+                                return [coordinate[1], coordinate[0]];
                             }),
                         }
                     }

--- a/src/Routes/FindRouteAPI.ts
+++ b/src/Routes/FindRouteAPI.ts
@@ -28,11 +28,6 @@ findRouteRouter.post("/", async (req: Request, res: Response) => {
     }
 
     coordinatesList.push([req.body.startCord[1], req.body.startCord[0]]);
-    if (req.body?.stopover !== undefined) {
-        coordinatesList.push(...req.body.stopover.map((coordinate: [number, number]) => {
-            return [coordinate[1], coordinate[0]];
-        }));
-    }
     coordinatesList.push([req.body.endCord[1], req.body.endCord[0]]);
 
     //weight_factor 1~2, share_factor 0.1~1

--- a/src/Routes/FindRouteAPI.ts
+++ b/src/Routes/FindRouteAPI.ts
@@ -11,6 +11,11 @@ findRouteRouter.post("/", async (req: Request, res: Response) => {
         RESULT_MSG: "Ready",
         RESULT_DATA: {}
     }
+    const alternativeRoutesObject = {
+        "target_count": 3,
+        "weight_factor": 2,
+        "share_factor": 1
+    };
 
     if (req.body?.startCord === undefined || req.body?.endCord === undefined) {
         RESULT_DATA['RESULT_CODE'] = 400;
@@ -25,14 +30,21 @@ findRouteRouter.post("/", async (req: Request, res: Response) => {
         }));
     }
     coordinatesList.push([req.body.endCord[1], req.body.endCord[0]]);
+
+    alternativeRoutesObject["target_count"] = req.body?.targetCount ?? alternativeRoutesObject["target_count"];
+    alternativeRoutesObject["weight_factor"] = req.body?.targetCount ?? alternativeRoutesObject["weight_factor"];
+    alternativeRoutesObject["share_factor"] = req.body?.targetCount ?? alternativeRoutesObject["share_factor"];
+    //weight_factor 1~2, share_factor 0.1~1
     try {
         const routeMsg = await axios.post(URL, {
-            coordinates: coordinatesList
+            "coordinates": coordinatesList,
+            "alternative_routes": alternativeRoutesObject,
         }, {
             headers: {
                 Authorization: process.env.OPENROUTESERVICE_KEY
             },
         });
+        console.log(routeMsg.status);
         RESULT_DATA["RESULT_CODE"] = routeMsg.status;
         RESULT_DATA["RESULT_MSG"] = routeMsg.statusText;
         if (routeMsg.status === 200) {

--- a/src/Routes/FindRouteAPI.ts
+++ b/src/Routes/FindRouteAPI.ts
@@ -1,21 +1,25 @@
 import express, {Request, Response} from "express";
-import axios from "axios";
+import axios, {AxiosError} from "axios";
 
 const findRouteRouter = express.Router();
 
 findRouteRouter.post("/", async (req: Request, res: Response) => {
     const URL: string = "https://api.openrouteservice.org/v2/directions/foot-walking/geojson";
-    const coordinatesList = [];
+    const coordinatesList: [number, number][] = [];
     const RESULT_DATA = {
         RESULT_CODE: 0,
         RESULT_MSG: "Ready",
         RESULT_DATA: {}
     }
-    const alternativeRoutesObject = {
+    const alternativeRoutesConfig = {
         "target_count": 3,
         "weight_factor": 2,
         "share_factor": 1
     };
+
+    alternativeRoutesConfig["target_count"] = req.body?.targetCount ?? alternativeRoutesConfig["target_count"];
+    alternativeRoutesConfig["weight_factor"] = req.body?.targetCount ?? alternativeRoutesConfig["weight_factor"];
+    alternativeRoutesConfig["share_factor"] = req.body?.targetCount ?? alternativeRoutesConfig["share_factor"];
 
     if (req.body?.startCord === undefined || req.body?.endCord === undefined) {
         RESULT_DATA['RESULT_CODE'] = 400;
@@ -31,20 +35,19 @@ findRouteRouter.post("/", async (req: Request, res: Response) => {
     }
     coordinatesList.push([req.body.endCord[1], req.body.endCord[0]]);
 
-    alternativeRoutesObject["target_count"] = req.body?.targetCount ?? alternativeRoutesObject["target_count"];
-    alternativeRoutesObject["weight_factor"] = req.body?.targetCount ?? alternativeRoutesObject["weight_factor"];
-    alternativeRoutesObject["share_factor"] = req.body?.targetCount ?? alternativeRoutesObject["share_factor"];
     //weight_factor 1~2, share_factor 0.1~1
     try {
-        const routeMsg = await axios.post(URL, {
+        const body = alternativeRoutesConfig.target_count === 1 ? {
             "coordinates": coordinatesList,
-            "alternative_routes": alternativeRoutesObject,
-        }, {
+        } : {
+            "coordinates": coordinatesList,
+            "alternative_routes": alternativeRoutesConfig,
+        }
+        const routeMsg = await axios.post(URL, body, {
             headers: {
                 Authorization: process.env.OPENROUTESERVICE_KEY
             },
         });
-        console.log(routeMsg.status);
         RESULT_DATA["RESULT_CODE"] = routeMsg.status;
         RESULT_DATA["RESULT_MSG"] = routeMsg.statusText;
         if (routeMsg.status === 200) {
@@ -59,9 +62,11 @@ findRouteRouter.post("/", async (req: Request, res: Response) => {
         }
         res.send(RESULT_DATA);
     } catch (err) {
-        RESULT_DATA["RESULT_CODE"] = 400;
-        RESULT_DATA["RESULT_MSG"] = err instanceof Error ? err.message : "400 not found";
-        res.send(RESULT_DATA);
+        if (err instanceof AxiosError) {
+            RESULT_DATA["RESULT_CODE"] = err.response?.status ?? 404;
+            RESULT_DATA["RESULT_MSG"] = err.response?.data.error.message ?? "Internal Server Error";
+            res.send(RESULT_DATA);
+        }
     }
 });
 

--- a/src/Routes/FindRouteAPI.ts
+++ b/src/Routes/FindRouteAPI.ts
@@ -52,11 +52,19 @@ findRouteRouter.post("/", async (req: Request, res: Response) => {
         RESULT_DATA["RESULT_MSG"] = routeMsg.statusText;
         if (routeMsg.status === 200) {
             RESULT_DATA['RESULT_DATA'] = {
-                coordinates: routeMsg.data.features[0].geometry.coordinates.map((coordinate: [number, number]) => {
+                routeList: routeMsg.data.features.map(({geometry: geometry}: any, index: number) => {
                     return {
-                        description: "walking",
-                        coordinate: [coordinate[1], coordinate[0]]
-                    };
+                        id: index,
+                        description: `Route ${index}`,
+                        route: {
+                            coordinates: geometry.coordinates.map((coordinate: [number, number]) => {
+                                return {
+                                    description: "walking",
+                                    coordinate: [coordinate[1], coordinate[0]]
+                                };
+                            }),
+                        }
+                    }
                 }),
             }
         }


### PR DESCRIPTION
## Summary
RouteList를 반환하는 API를 구성했습니다.

## Description
기존에 있는 http://localhost:8080/findRouter

__요청 BODY__ 양식은 다음과 같습니다.
 ```json
{
  "startCord": [8.681495, 49.41461],
  "endCord": [8.687872, 49.420318],
  "targetCount": 2,
}
```
startCord : 좌표의 시작점을 [위도, 경도] 형식으로 받습니다.
endCord : 좌표의 종료지점을 [위도, 경도] 형식으로 받습니다.
targetCount (optional) : 반환할 경로 개수를 지정합니다. 설정하지 않으면 가능한 한 최대 경로를 가져옵니다. (여기서는 임시로 최대 3개)


__에서 POST 요청을 보내면 반환하는 데이터를 다음과 같이 수정했습니다.__
```json
{
    "RESULT_CODE": 200,
    "RESULT_MSG": "OK",
    "RESULT_DATA": {
        "routeList":  [
               {
                "id": 0,
                "description": "Route 0",
                "route": {
                    "distance": 104,
                    "duration": 110,
                    "steps": [
                       {
                          "distance": 5,
                          "duration": 6,
                          "type": "출발",
                          "name": "Head west on Gerhart-Hauptmann-Straße",
                          "wayPoints": [0, 1],
                       },
                       {
                          "distance": 10,
                          "duration": 2,
                          "type": "좌회전",
                          "name": "Head west on Gerhart-Hauptmann-Straße",
                          "wayPoints": [1, 6],
                       },
                       {
                          "distance": 20,
                          "duration": 40,
                          "type": "우회전",
                          "name": "Head west on Gerhart-Hauptmann-Straße",
                         "wayPoints": [6, 10],
                       },
                       {},
                       {},
                     ],
                    "coordinates": [
                        [0, 0],
                        [1, 2],
                        [2, 3],
                        [], 
                    ],
                }
            },
            {
                "id": 1,
                "description": "Route 1",
                "route": {
                    "distance": 104,
                    "duration": 110,
                    "steps": {
                       "distance": 5,
                       "duration": 6,
                       "type": "출발",
                       "name": "Head west on Gerhart-Hauptmann-Straße",
                       "wayPoints": [0, 1],
                    },
                    "coordinates": [
                        [0, 0],
                        [1, 2],
                        [2, 3]
                    ],
                }
            },
            {
            
            },
        ]
    }
}
```

## res가 성공하면 다음 데이터를 반환합니다.  
`routeList`: post 요청이 성공하면 반환하는 경로의 배열입니다.

## 각 경로는 다음 객체로 이루어져 있습니다.  
`id`: 경로의 고유 식별자값입니다. 0부터 시작합니다.
`description`: 경로의 이름입니다.
`route`: 세부 경로 데이터 입니다.
## `route` 객체는 다음으로 이루어져있습니다.  

`distance`: 해당 경로의 전체 거리입니다.
`duration`: 해당 경로의 전체 소요시간입니다.
`steps` : 각 경로의 세부 단계의 설명이 들어있습니다.
`coordinates`: `steps` 객체에 있는 wayPoint객체가 가리키는 index의 원소들입니다. 위도와 경도가 들어있습니다.
  
## `steps`객체는 다음 원소들로 이루어져있습니다.    
`distance`: 각 구간의 거리입니다.
`duration`: 각 구간의 소요시간입니다.
`type`: 각 구간에서의 사용자 행동 방식입니다.
`name`: 각 구간에서의 사용자가 행동해야하는 설명입니다.
`wayPoints`: 기존 `route`객체의 원소인 coordinate의 index를 가지고 있습니다. 만약 해당 step의 wayPoint가 [3, 9]라면 
coordinates[3]에서 coodinate[9]까지 거리가 distance이며, 소요시간이 duration이고, 이 구간 사이 사용자는 type을 해야하며, 해당 step에 대한 전체적인 설명은 name에 있습니다. 
* 반드시 한 step의 wayPoint가 9로 끝난다면 다음 step의 wayPoint는 9로 시작합니다.
* 처음은 반드시 type이 출발이며, wayPoints는 0으로 시작합니다.
* 마지막은 반드시 type이 종료이며, wayPoints는 len(coordinates)로 끝나야 합니다.
