### PR TITLE
[DEV] BE Weather 관련 API 구성

### DIFF
--- a/src/Routes/WeatherAPI.ts
+++ b/src/Routes/WeatherAPI.ts
@@ -3,6 +3,12 @@ import express, { Request, Response } from "express";
 const weatherRouter = express.Router();
 
 weatherRouter.get("/getWeatherInfo", async (req: Request, res: Response) => {
+    const API_KEY = process.env.OPENWEATHER_KEY;
+    const lat = req.params.lat;
+    const lon = req.params.lon;
+
+    const apiUrl = `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=${API_KEY}`;
+
     res.send("Get Weather API Router");
 });
 

--- a/src/Routes/WeatherAPI.ts
+++ b/src/Routes/WeatherAPI.ts
@@ -4,8 +4,8 @@ const weatherRouter = express.Router();
 
 weatherRouter.get("/getWeatherInfo", async (req: Request, res: Response) => {
     const API_KEY = process.env.OPENWEATHER_KEY;
-    const lat = req.params.lat;
-    const lon = req.params.lon;
+    const lat = req.query.lat;
+    const lon = req.query.lon;
 
     const apiUrl = `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=${API_KEY}`;
 

--- a/src/Routes/WeatherAPI.ts
+++ b/src/Routes/WeatherAPI.ts
@@ -1,15 +1,34 @@
 import express, { Request, Response } from "express";
+import axios from "axios";
 
 const weatherRouter = express.Router();
 
 weatherRouter.get("/getWeatherInfo", async (req: Request, res: Response) => {
+    const RESULT_DATA = {
+        RESULT_CODE: 0,
+        RESULT_MSG: "Ready",
+        RESULT_DATA: {}
+    }
+
     const API_KEY = process.env.OPENWEATHER_KEY;
     const lat = req.query.lat;
     const lon = req.query.lon;
 
     const apiUrl = `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=${API_KEY}`;
+    await axios.get(apiUrl)
+        .then((res) => {
+            RESULT_DATA.RESULT_DATA = res["data"]["weather"][0];
+            Object.assign(RESULT_DATA.RESULT_DATA, res["data"]["main"]);
 
-    res.send("Get Weather API Router");
+            RESULT_DATA.RESULT_CODE = 200;
+            RESULT_DATA.RESULT_MSG = "Success";
+        })
+        .catch((err) => {
+            RESULT_DATA.RESULT_CODE = 100;
+            RESULT_DATA.RESULT_MSG = err.toString();
+        });
+
+    res.send(RESULT_DATA);
 });
 
 export default weatherRouter;


### PR DESCRIPTION
## Summary
BE에 Weather 관련 API를 구성하였습니다.

## Description
- Open Weather API에 연동한 Weather 관련 API를 구성하였습니다.
- `/weather/getWeatherInfo`에 GET 형식으로 `lat`과 `lon` 값을 Query-String으로 지정해 전송하면 다음과 같은 형식으로 응답을 반환합니다.
```json
{
  "RESULT_CODE": 200,
  "RESULT_MSG": "Success",
  "RESULT_DATA": {
    "id": 800,
    "main": "Clear",
    "description": "clear sky",
    "icon": "01n",
    "temp": 272.12,
    "feels_like": 272.12,
    "temp_min": 272.12,
    "temp_max": 272.12,
    "pressure": 1028,
    "humidity": 55,
    "sea_level": 1028,
    "grnd_level": 1016
  }
}
```